### PR TITLE
Redundant paths

### DIFF
--- a/bgp-2/README.md
+++ b/bgp-2/README.md
@@ -1,41 +1,375 @@
-This vagrant project brings up a 3 networks connected via BGP with a single server on each network.  AS100 and AS200 are directly connected, but AS300 sits within AS200s network and is not connected to AS100, so transitive routing must occur at `r2`.
+This vagrant project brings up a 4 networks connected via BGP with a single server on each network. The purpose of this is to create a more complex topology that includes multiple available routes per router.  Success here means that any device can contact any other device in the event of any single router failure except for those on the failed router's network.
 
 Largely based on tutorial at http://xmodulo.com/centos-bgp-router-quagga.html
 
 ```
-+--------------------------+                                          +--------------------------+
-|             +------------------+                              +------------------+             |
-| r1 (router) | WAN(eth1):       |        192.168.50.0/24       | WAN(eth1):       | r2 (router) |
-| AS100       | 192.168.50.10/24 +------------------------------+ 192.168.50.20/24 |       AS200 |
-|             +------------+-----+                              +-----+------------+             |
-| +-------------------+    |                                          |   +-------------------+  |
-| | LAN(eth2):        |    |                                          |   | LAN(eth2):        |  |
-+-+  192.168.10.2/24  +----+                                          +---+  192.168.20.2/24  +--+
-  +----------+--------+                                                   +---------+---------+
-             |                    +--------------------------+                      |
-       192.168.10.0/24            |             +-----------------+           192.168.20.0/24
-             +                    | r3 (router) | WAN(eth1):      +-----------------+
-             |                    | AS300       | 192.168.20.3/24 |                 |
-  +----------+---------+          |             +------------+----+      +----------+---------+
-+-+ LAN(eth1):         +-+        | +-------------------+    |           | LAN(eth1):         |
-| |  192.168.10.100/24 | |        | | LAN(eth2):        |    |         +-+  192.168.20.100/24 +-+
-| +--------------------+ |        +-+  192.168.10.2/24  +----+         | +--------------------+ |
-| s1 (server)            |          +----------+--------+              | s2 (server)            |
-|                        |                     |                       |                        |
-+------------------------+                     |                       +------------------------+
-                                          192.168.30.0/24
-                                               |
-                                     +---------+----------+
-                                     | LAN(eth1):         |
-                                   +-+  192.168.30.100/24 +-+
-                                   | +--------------------+ |
-                                   | s3 (server)            |
-                                   |                        |
-                                   +------------------------+
-```
+
+                       +--------------------------+                                          +--------------------------+
+                       |             +------------------+                              +------------------+             |
+                       | r1 (router) |     eth1         |        192.168.50.0/24       |     eth1         | r2 (router) |
+                       | AS100       | 192.168.50.10/24 +------------------------------+ 192.168.50.20/24 |       AS200 |
+                       |             +------------------+                              +------------------+             |
+                       | +-------------------+    |                                          |   +-------------------+  |
+                       | |     eth2          |    |                                          |   |     eth2          |  |
+                       +-+  192.168.10.2/24  +----+                                          +---+  192.168.20.2/24  +--+
+                         +--------+----------+                                                   +---------+---------+
+                                  |                                                                        |
+                           192.168.10.0/24                                                           192.168.20.0/24
+                                  |                                                                        |
+              +-------------------+-----------+                                              +-------------+--------------+
+              |                               |                                              |                            |
+   +----------+---------+           +---------+-------+                              +-----------------+         +--------------------+
+ +-+     eth1           +-+       +-+     eth2        +---+                        +-+     eth1        +---+     |     eth1           |
+ | |  192.168.10.100/24 | |       | | 192.168.10.4/24 |   |                        | | 192.168.20.3/24 |   |   +-+  192.168.20.100/24 +-+
+ | +--------------------+ |       | +-----------------+   |                        | +-----------------+   |   | +--------------------+ |
+ | s1 (server)            |       | r4 (router) +-----------------+                |           r3 (router) |   | s2 (server)            |
+ |                        |       | AS400       |    eth1         |                |                AS300  |   |                        |
+ +------------------------+       |             | 192.168.30.3/24 |                |                       |   +------------------------+
+                                  |             +--------------+--+                |                       |
+                                  | +-----------------+   |    |                   | +-------------------+ |
+                                  +-+    eth3         +---+    |                   +-+     eth2          +-+
+                                    | 192.168.40.2/24 |        |                     |  192.168.30.2/24  |
+                                    +--------+--------+        |                     +-------------------+
+                                             |                 |                                |
+                                       192.168.40.0/24         +--------------------------------+
+                                             |                                                  |
+                                   +---------+----------+                                       |
+                                   |     eth1           |                                  192.168.30.0/24
+                                 +-+  192.168.40.100/24 +-+                                     |
+                                 | +--------------------+ |                           +---------+----------+
+                                 | s4 (server)            |                           |     eth1           |
+                                 |                        |                         +-+  192.168.30.100/24 +-+
+                                 +------------------------+                         | +--------------------+ |
+                                                                                    | s3 (server)            |
+                                                                                    |                        |
+                                                                                    +------------------------+
+
+
+## AS100
+
+Announces routes to:
+* AS400
+* AS100
+
+## AS200
+
+Announces routes to:
+* AS100
+* AS300
+
+# AS300
+
+Announces routes to:
+* AS400
+* AS200
+
+# AS400
+
+Announces routes to:
+* AS300
+* AS100
+
 
 ```
-./test.sh
+$ ./test.sh
+r1
+========================
+ip route list:
+default via 10.0.2.2 dev eth0
+10.0.2.0/24 dev eth0  proto kernel  scope link  src 10.0.2.15
+192.168.10.0/24 dev eth2  proto kernel  scope link  src 192.168.10.2
+192.168.20.0/24 via 192.168.50.20 dev eth1  proto zebra
+192.168.30.0/24 via 192.168.10.4 dev eth2  proto zebra
+192.168.40.0/24 via 192.168.10.4 dev eth2  proto zebra
+192.168.50.0/24 dev eth1  proto kernel  scope link  src 192.168.50.10
+BGP
+BGP table version is 0, local router ID is 192.168.50.10
+Status codes: s suppressed, d damped, h history, * valid, > best, = multipath,
+              i internal, r RIB-failure, S Stale, R Removed
+Origin codes: i - IGP, e - EGP, ? - incomplete
+
+   Network          Next Hop            Metric LocPrf Weight Path
+*  192.168.10.0     192.168.10.4             0             0 400 i
+*>                  0.0.0.0                  0         32768 i
+*  192.168.20.0     192.168.10.4                           0 400 300 i
+*>                  192.168.50.20            0             0 200 i
+*> 192.168.30.0     192.168.10.4             0             0 400 i
+*                   192.168.50.20                          0 200 300 i
+*  192.168.40.0     192.168.50.20                          0 200 300 400 i
+*>                  192.168.10.4             0             0 400 i
+*  192.168.50.0     192.168.50.20            0             0 200 i
+*>                  0.0.0.0                  0         32768 i
+
+Total number of prefixes 5
+BGP router identifier 192.168.50.10, local AS number 100
+RIB entries 9, using 1008 bytes of memory
+Peers 2, using 9136 bytes of memory
+
+Neighbor        V    AS MsgRcvd MsgSent   TblVer  InQ OutQ Up/Down  State/PfxRcd
+192.168.10.4    4   400      42      50        0    0    0 00:20:09        4
+192.168.50.20   4   200      48      53        0    0    0 00:21:44        4
+
+Total number of neighbors 2
+r1 -> 192.168.50.10:  0% packet loss
+r1 -> 192.168.10.2:  0% packet loss
+r1 -> 192.168.50.20:  0% packet loss
+r1 -> 192.168.20.2:  0% packet loss
+r1 -> 192.168.20.3:  0% packet loss
+r1 -> 192.168.30.2:  0% packet loss
+r1 -> 192.168.30.3:  0% packet loss
+r1 -> 192.168.10.4:  0% packet loss
+r1 -> 192.168.40.2:  0% packet loss
+r1 -> 192.168.10.100:  0% packet loss
+r1 -> 192.168.20.100:  0% packet loss
+r1 -> 192.168.30.100:  0% packet loss
+r1 -> 192.168.40.100:  0% packet loss
+Connection to 127.0.0.1 closed.
+r2
+========================
+ip route list:
+default via 10.0.2.2 dev eth0
+10.0.2.0/24 dev eth0  proto kernel  scope link  src 10.0.2.15
+192.168.10.0/24 via 192.168.50.10 dev eth1  proto zebra
+192.168.20.0/24 dev eth2  proto kernel  scope link  src 192.168.20.2
+192.168.30.0/24 via 192.168.20.3 dev eth2  proto zebra
+192.168.40.0/24 via 192.168.20.3 dev eth2  proto zebra
+192.168.50.0/24 dev eth1  proto kernel  scope link  src 192.168.50.20
+BGP
+BGP table version is 0, local router ID is 192.168.50.20
+Status codes: s suppressed, d damped, h history, * valid, > best, = multipath,
+              i internal, r RIB-failure, S Stale, R Removed
+Origin codes: i - IGP, e - EGP, ? - incomplete
+
+   Network          Next Hop            Metric LocPrf Weight Path
+*  192.168.10.0     192.168.20.3                           0 300 400 i
+*>                  192.168.50.10            0             0 100 i
+*  192.168.20.0     192.168.20.3             0             0 300 i
+*>                  0.0.0.0                  0         32768 i
+*  192.168.30.0     192.168.50.10                          0 100 400 i
+*>                  192.168.20.3             0             0 300 i
+*  192.168.40.0     192.168.50.10                          0 100 400 i
+*>                  192.168.20.3                           0 300 400 i
+*  192.168.50.0     192.168.50.10            0             0 100 i
+*>                  0.0.0.0                  0         32768 i
+
+Total number of prefixes 5
+BGP router identifier 192.168.50.20, local AS number 200
+RIB entries 9, using 1008 bytes of memory
+Peers 2, using 9136 bytes of memory
+
+Neighbor        V    AS MsgRcvd MsgSent   TblVer  InQ OutQ Up/Down  State/PfxRcd
+192.168.20.3    4   300      29      26        0    0    0 00:21:52        4
+192.168.50.10   4   100      29      30        0    0    0 00:21:47        4
+
+Total number of neighbors 2
+r2 -> 192.168.50.10:  0% packet loss
+r2 -> 192.168.10.2:  0% packet loss
+r2 -> 192.168.50.20:  0% packet loss
+r2 -> 192.168.20.2:  0% packet loss
+r2 -> 192.168.20.3:  0% packet loss
+r2 -> 192.168.30.2:  0% packet loss
+r2 -> 192.168.30.3:  0% packet loss
+r2 -> 192.168.10.4:  0% packet loss
+r2 -> 192.168.40.2:  0% packet loss
+r2 -> 192.168.10.100:  0% packet loss
+r2 -> 192.168.20.100:  0% packet loss
+r2 -> 192.168.30.100:  0% packet loss
+r2 -> 192.168.40.100:  0% packet loss
+Connection to 127.0.0.1 closed.
+r3
+========================
+ip route list:
+default via 10.0.2.2 dev eth0
+10.0.2.0/24 dev eth0  proto kernel  scope link  src 10.0.2.15
+192.168.10.0/24 via 192.168.30.3 dev eth2  proto zebra
+192.168.20.0/24 dev eth1  proto kernel  scope link  src 192.168.20.3
+192.168.30.0/24 dev eth2  proto kernel  scope link  src 192.168.30.2
+192.168.40.0/24 via 192.168.30.3 dev eth2  proto zebra
+192.168.50.0/24 via 192.168.20.2 dev eth1  proto zebra
+BGP
+BGP table version is 0, local router ID is 192.168.20.3
+Status codes: s suppressed, d damped, h history, * valid, > best, = multipath,
+              i internal, r RIB-failure, S Stale, R Removed
+Origin codes: i - IGP, e - EGP, ? - incomplete
+
+   Network          Next Hop            Metric LocPrf Weight Path
+*> 192.168.10.0     192.168.30.3             0             0 400 i
+*                   192.168.20.2                           0 200 100 i
+*  192.168.20.0     192.168.20.2             0             0 200 i
+*>                  0.0.0.0                  0         32768 i
+*  192.168.30.0     192.168.30.3             0             0 400 i
+*>                  0.0.0.0                  0         32768 i
+*> 192.168.40.0     192.168.30.3             0             0 400 i
+*  192.168.50.0     192.168.30.3                           0 400 100 i
+*>                  192.168.20.2             0             0 200 i
+
+Total number of prefixes 5
+BGP router identifier 192.168.20.3, local AS number 300
+RIB entries 9, using 1008 bytes of memory
+Peers 2, using 9136 bytes of memory
+
+Neighbor        V    AS MsgRcvd MsgSent   TblVer  InQ OutQ Up/Down  State/PfxRcd
+192.168.20.2    4   200      45      53        0    0    0 00:21:54        3
+192.168.30.3    4   400      41      50        0    0    0 00:20:16        4
+
+Total number of neighbors 2
+r3 -> 192.168.50.10:  0% packet loss
+r3 -> 192.168.10.2:  0% packet loss
+r3 -> 192.168.50.20:  0% packet loss
+r3 -> 192.168.20.2:  0% packet loss
+r3 -> 192.168.20.3:  0% packet loss
+r3 -> 192.168.30.2:  0% packet loss
+r3 -> 192.168.30.3:  0% packet loss
+r3 -> 192.168.10.4:  0% packet loss
+r3 -> 192.168.40.2:  0% packet loss
+r3 -> 192.168.10.100:  0% packet loss
+r3 -> 192.168.20.100:  0% packet loss
+r3 -> 192.168.30.100:  0% packet loss
+r3 -> 192.168.40.100:  0% packet loss
+Connection to 127.0.0.1 closed.
+r4
+========================
+ip route list:
+default via 10.0.2.2 dev eth0
+10.0.2.0/24 dev eth0  proto kernel  scope link  src 10.0.2.15
+192.168.10.0/24 dev eth2  proto kernel  scope link  src 192.168.10.4
+192.168.20.0/24 via 192.168.30.2 dev eth1  proto zebra
+192.168.30.0/24 dev eth1  proto kernel  scope link  src 192.168.30.3
+192.168.40.0/24 dev eth3  proto kernel  scope link  src 192.168.40.2
+192.168.50.0/24 via 192.168.10.2 dev eth2  proto zebra
+BGP
+BGP table version is 0, local router ID is 192.168.30.3
+Status codes: s suppressed, d damped, h history, * valid, > best, = multipath,
+              i internal, r RIB-failure, S Stale, R Removed
+Origin codes: i - IGP, e - EGP, ? - incomplete
+
+   Network          Next Hop            Metric LocPrf Weight Path
+*  192.168.10.0     192.168.10.2             0             0 100 i
+*>                  0.0.0.0                  0         32768 i
+*  192.168.20.0     192.168.10.2                           0 100 200 i
+*>                  192.168.30.2             0             0 300 i
+*  192.168.30.0     192.168.30.2             0             0 300 i
+*>                  0.0.0.0                  0         32768 i
+*> 192.168.40.0     0.0.0.0                  0         32768 i
+*> 192.168.50.0     192.168.10.2             0             0 100 i
+*                   192.168.30.2                           0 300 200 i
+
+Total number of prefixes 5
+BGP router identifier 192.168.30.3, local AS number 400
+RIB entries 9, using 1008 bytes of memory
+Peers 2, using 9136 bytes of memory
+
+Neighbor        V    AS MsgRcvd MsgSent   TblVer  InQ OutQ Up/Down  State/PfxRcd
+192.168.10.2    4   100      26      27        0    0    0 00:20:17        3
+192.168.30.2    4   300      26      25        0    0    0 00:20:19        3
+
+Total number of neighbors 2
+r4 -> 192.168.50.10:  0% packet loss
+r4 -> 192.168.10.2:  0% packet loss
+r4 -> 192.168.50.20:  0% packet loss
+r4 -> 192.168.20.2:  0% packet loss
+r4 -> 192.168.20.3:  0% packet loss
+r4 -> 192.168.30.2:  0% packet loss
+r4 -> 192.168.30.3:  0% packet loss
+r4 -> 192.168.10.4:  0% packet loss
+r4 -> 192.168.40.2:  0% packet loss
+r4 -> 192.168.10.100:  0% packet loss
+r4 -> 192.168.20.100:  0% packet loss
+r4 -> 192.168.30.100:  0% packet loss
+r4 -> 192.168.40.100:  0% packet loss
+Connection to 127.0.0.1 closed.
+s1
+========================
+ip route list:
+default via 10.0.2.2 dev eth0
+10.0.2.0/24 dev eth0  proto kernel  scope link  src 10.0.2.15
+192.168.0.0/16 via 192.168.10.2 dev eth1
+192.168.10.0/24 dev eth1  proto kernel  scope link  src 192.168.10.100
+s1 -> 192.168.50.10:  0% packet loss
+s1 -> 192.168.10.2:  0% packet loss
+s1 -> 192.168.50.20:  0% packet loss
+s1 -> 192.168.20.2:  0% packet loss
+s1 -> 192.168.20.3:  0% packet loss
+s1 -> 192.168.30.2:  0% packet loss
+s1 -> 192.168.30.3:  0% packet loss
+s1 -> 192.168.10.4:  0% packet loss
+s1 -> 192.168.40.2:  0% packet loss
+s1 -> 192.168.10.100:  0% packet loss
+s1 -> 192.168.20.100:  0% packet loss
+s1 -> 192.168.30.100:  0% packet loss
+s1 -> 192.168.40.100:  0% packet loss
+Connection to 127.0.0.1 closed.
+s2
+========================
+ip route list:
+default via 10.0.2.2 dev eth0
+10.0.2.0/24 dev eth0  proto kernel  scope link  src 10.0.2.15
+192.168.0.0/16 via 192.168.20.2 dev eth1
+192.168.20.0/24 dev eth1  proto kernel  scope link  src 192.168.20.100
+s2 -> 192.168.50.10:  0% packet loss
+s2 -> 192.168.10.2:  0% packet loss
+s2 -> 192.168.50.20:  0% packet loss
+s2 -> 192.168.20.2:  0% packet loss
+s2 -> 192.168.20.3:  0% packet loss
+s2 -> 192.168.30.2:  0% packet loss
+s2 -> 192.168.30.3:  0% packet loss
+s2 -> 192.168.10.4:  0% packet loss
+s2 -> 192.168.40.2:  0% packet loss
+s2 -> 192.168.10.100:  0% packet loss
+s2 -> 192.168.20.100:  0% packet loss
+s2 -> 192.168.30.100:  0% packet loss
+s2 -> 192.168.40.100:  0% packet loss
+Connection to 127.0.0.1 closed.
+s3
+========================
+ip route list:
+default via 10.0.2.2 dev eth0
+10.0.2.0/24 dev eth0  proto kernel  scope link  src 10.0.2.15
+192.168.0.0/16 via 192.168.30.2 dev eth1
+192.168.30.0/24 dev eth1  proto kernel  scope link  src 192.168.30.100
+s3 -> 192.168.50.10:  0% packet loss
+s3 -> 192.168.10.2:  0% packet loss
+s3 -> 192.168.50.20:  0% packet loss
+s3 -> 192.168.20.2:  0% packet loss
+s3 -> 192.168.20.3:  0% packet loss
+s3 -> 192.168.30.2:  0% packet loss
+s3 -> 192.168.30.3:  0% packet loss
+s3 -> 192.168.10.4:  0% packet loss
+s3 -> 192.168.40.2:  0% packet loss
+s3 -> 192.168.10.100:  0% packet loss
+s3 -> 192.168.20.100:  0% packet loss
+s3 -> 192.168.30.100:  0% packet loss
+s3 -> 192.168.40.100:  0% packet loss
+Connection to 127.0.0.1 closed.
+s4
+========================
+ip route list:
+default via 10.0.2.2 dev eth0
+10.0.2.0/24 dev eth0  proto kernel  scope link  src 10.0.2.15
+192.168.0.0/16 via 192.168.40.2 dev eth1
+192.168.40.0/24 dev eth1  proto kernel  scope link  src 192.168.40.100
+s4 -> 192.168.50.10:  0% packet loss
+s4 -> 192.168.10.2:  0% packet loss
+s4 -> 192.168.50.20:  0% packet loss
+s4 -> 192.168.20.2:  0% packet loss
+s4 -> 192.168.20.3:  0% packet loss
+s4 -> 192.168.30.2:  0% packet loss
+s4 -> 192.168.30.3:  0% packet loss
+s4 -> 192.168.10.4:  0% packet loss
+s4 -> 192.168.40.2:  0% packet loss
+s4 -> 192.168.10.100:  0% packet loss
+s4 -> 192.168.20.100:  0% packet loss
+s4 -> 192.168.30.100:  0% packet loss
+s4 -> 192.168.40.100:  0% packet loss
+Connection to 127.0.0.1 closed.
+```
+
+Running `test.sh` after shutting down `quagga` on `r4` yields all devices still
+reachable except for 192.168.40.0/24 and `r4`s interfaces.:
+
+```
+vagrant@r4:~$ sudo systemctl stop quagga
+$ ./test.sh
 r1
 ========================
 ip route list:
@@ -45,8 +379,7 @@ default via 10.0.2.2 dev eth0
 192.168.20.0/24 via 192.168.50.20 dev eth1  proto zebra
 192.168.30.0/24 via 192.168.50.20 dev eth1  proto zebra
 192.168.50.0/24 dev eth1  proto kernel  scope link  src 192.168.50.10
-Connection to 127.0.0.1 closed.
-show ip bgp:
+BGP
 BGP table version is 0, local router ID is 192.168.50.10
 Status codes: s suppressed, d damped, h history, * valid, > best, = multipath,
               i internal, r RIB-failure, S Stale, R Removed
@@ -56,28 +389,33 @@ Origin codes: i - IGP, e - EGP, ? - incomplete
 *> 192.168.10.0     0.0.0.0                  0         32768 i
 *> 192.168.20.0     192.168.50.20            0             0 200 i
 *> 192.168.30.0     192.168.50.20                          0 200 300 i
-*> 192.168.50.0     192.168.50.20            0             0 200 i
+*  192.168.50.0     192.168.50.20            0             0 200 i
+*>                  0.0.0.0                  0         32768 i
 
 Total number of prefixes 4
 BGP router identifier 192.168.50.10, local AS number 100
 RIB entries 7, using 784 bytes of memory
-Peers 1, using 4568 bytes of memory
+Peers 2, using 9136 bytes of memory
 
 Neighbor        V    AS MsgRcvd MsgSent   TblVer  InQ OutQ Up/Down  State/PfxRcd
-192.168.50.20   4   200      83      86        0    0    0 00:54:16        3
+192.168.10.4    4   400      50      57        0    0    0 00:00:11 Active
+192.168.50.20   4   200      57      62        0    0    0 00:29:16        3
 
-Total number of neighbors 1
-Connection to 127.0.0.1 closed.
-r1 -> 192.168.10.100:  0% packet loss
-r1 -> 192.168.20.100:  0% packet loss
-r1 -> 192.168.30.100:  0% packet loss
+Total number of neighbors 2
+r1 -> 192.168.50.10:  0% packet loss
 r1 -> 192.168.10.2:  0% packet loss
+r1 -> 192.168.50.20:  0% packet loss
 r1 -> 192.168.20.2:  0% packet loss
 r1 -> 192.168.20.3:  0% packet loss
 r1 -> 192.168.30.2:  0% packet loss
-r1 -> 192.168.50.10:  0% packet loss
-r1 -> 192.168.50.20:  0% packet loss
-
+r1 -> 192.168.30.3:  100% packet loss
+r1 -> 192.168.10.4:  0% packet loss
+r1 -> 192.168.40.2:  0% packet loss
+r1 -> 192.168.10.100:  0% packet loss
+r1 -> 192.168.20.100:  0% packet loss
+r1 -> 192.168.30.100:  0% packet loss
+r1 -> 192.168.40.100:  0% packet loss
+Connection to 127.0.0.1 closed.
 r2
 ========================
 ip route list:
@@ -87,8 +425,7 @@ default via 10.0.2.2 dev eth0
 192.168.20.0/24 dev eth2  proto kernel  scope link  src 192.168.20.2
 192.168.30.0/24 via 192.168.20.3 dev eth2  proto zebra
 192.168.50.0/24 dev eth1  proto kernel  scope link  src 192.168.50.20
-Connection to 127.0.0.1 closed.
-show ip bgp:
+BGP
 BGP table version is 0, local router ID is 192.168.50.20
 Status codes: s suppressed, d damped, h history, * valid, > best, = multipath,
               i internal, r RIB-failure, S Stale, R Removed
@@ -96,9 +433,11 @@ Origin codes: i - IGP, e - EGP, ? - incomplete
 
    Network          Next Hop            Metric LocPrf Weight Path
 *> 192.168.10.0     192.168.50.10            0             0 100 i
-*> 192.168.20.0     0.0.0.0                  0         32768 i
+*  192.168.20.0     192.168.20.3             0             0 300 i
+*>                  0.0.0.0                  0         32768 i
 *> 192.168.30.0     192.168.20.3             0             0 300 i
-*> 192.168.50.0     0.0.0.0                  0         32768 i
+*  192.168.50.0     192.168.50.10            0             0 100 i
+*>                  0.0.0.0                  0         32768 i
 
 Total number of prefixes 4
 BGP router identifier 192.168.50.20, local AS number 200
@@ -106,21 +445,24 @@ RIB entries 7, using 784 bytes of memory
 Peers 2, using 9136 bytes of memory
 
 Neighbor        V    AS MsgRcvd MsgSent   TblVer  InQ OutQ Up/Down  State/PfxRcd
-192.168.20.3    4   300      57      59        0    0    0 00:54:48        1
-192.168.50.10   4   100      57      59        0    0    0 00:54:46        1
+192.168.20.3    4   300      38      34        0    0    0 00:29:34        2
+192.168.50.10   4   100      38      39        0    0    0 00:29:29        2
 
 Total number of neighbors 2
-Connection to 127.0.0.1 closed.
-r2 -> 192.168.10.100:  0% packet loss
-r2 -> 192.168.20.100:  0% packet loss
-r2 -> 192.168.30.100:  0% packet loss
+r2 -> 192.168.50.10:  0% packet loss
 r2 -> 192.168.10.2:  0% packet loss
+r2 -> 192.168.50.20:  0% packet loss
 r2 -> 192.168.20.2:  0% packet loss
 r2 -> 192.168.20.3:  0% packet loss
 r2 -> 192.168.30.2:  0% packet loss
-r2 -> 192.168.50.10:  0% packet loss
-r2 -> 192.168.50.20:  0% packet loss
-
+r2 -> 192.168.30.3:  100% packet loss
+r2 -> 192.168.10.4:  100% packet loss
+r2 -> 192.168.40.2:  0% packet loss
+r2 -> 192.168.10.100:  0% packet loss
+r2 -> 192.168.20.100:  0% packet loss
+r2 -> 192.168.30.100:  0% packet loss
+r2 -> 192.168.40.100:  0% packet loss
+Connection to 127.0.0.1 closed.
 r3
 ========================
 ip route list:
@@ -130,8 +472,7 @@ default via 10.0.2.2 dev eth0
 192.168.20.0/24 dev eth1  proto kernel  scope link  src 192.168.20.3
 192.168.30.0/24 dev eth2  proto kernel  scope link  src 192.168.30.2
 192.168.50.0/24 via 192.168.20.2 dev eth1  proto zebra
-Connection to 127.0.0.1 closed.
-show ip bgp:
+BGP
 BGP table version is 0, local router ID is 192.168.20.3
 Status codes: s suppressed, d damped, h history, * valid, > best, = multipath,
               i internal, r RIB-failure, S Stale, R Removed
@@ -139,30 +480,60 @@ Origin codes: i - IGP, e - EGP, ? - incomplete
 
    Network          Next Hop            Metric LocPrf Weight Path
 *> 192.168.10.0     192.168.20.2                           0 200 100 i
-*> 192.168.20.0     192.168.20.2             0             0 200 i
+*  192.168.20.0     192.168.20.2             0             0 200 i
+*>                  0.0.0.0                  0         32768 i
 *> 192.168.30.0     0.0.0.0                  0         32768 i
 *> 192.168.50.0     192.168.20.2             0             0 200 i
 
 Total number of prefixes 4
 BGP router identifier 192.168.20.3, local AS number 300
 RIB entries 7, using 784 bytes of memory
-Peers 1, using 4568 bytes of memory
+Peers 2, using 9136 bytes of memory
 
 Neighbor        V    AS MsgRcvd MsgSent   TblVer  InQ OutQ Up/Down  State/PfxRcd
-192.168.20.2    4   200      84      86        0    0    0 00:55:19        3
+192.168.20.2    4   200      53      62        0    0    0 00:29:56        3
+192.168.30.3    4   400      49      57        0    0    0 00:00:46 Active
 
-Total number of neighbors 1
-Connection to 127.0.0.1 closed.
-r3 -> 192.168.10.100:  0% packet loss
-r3 -> 192.168.20.100:  0% packet loss
-r3 -> 192.168.30.100:  0% packet loss
+Total number of neighbors 2
+r3 -> 192.168.50.10:  0% packet loss
 r3 -> 192.168.10.2:  0% packet loss
+r3 -> 192.168.50.20:  0% packet loss
 r3 -> 192.168.20.2:  0% packet loss
 r3 -> 192.168.20.3:  0% packet loss
 r3 -> 192.168.30.2:  0% packet loss
-r3 -> 192.168.50.10:  0% packet loss
-r3 -> 192.168.50.20:  0% packet loss
-
+r3 -> 192.168.30.3:  0% packet loss
+r3 -> 192.168.10.4:  100% packet loss
+r3 -> 192.168.40.2:  0% packet loss
+r3 -> 192.168.10.100:  0% packet loss
+r3 -> 192.168.20.100:  0% packet loss
+r3 -> 192.168.30.100:  0% packet loss
+r3 -> 192.168.40.100:  0% packet loss
+Connection to 127.0.0.1 closed.
+r4
+========================
+ip route list:
+default via 10.0.2.2 dev eth0
+10.0.2.0/24 dev eth0  proto kernel  scope link  src 10.0.2.15
+192.168.10.0/24 dev eth2  proto kernel  scope link  src 192.168.10.4
+192.168.30.0/24 dev eth1  proto kernel  scope link  src 192.168.30.3
+192.168.40.0/24 dev eth3  proto kernel  scope link  src 192.168.40.2
+BGP
+Exiting: failed to connect to any daemons.
+Exiting: failed to connect to any daemons.
+r4 -> 192.168.50.10:  0% packet loss
+r4 -> 192.168.10.2:  0% packet loss
+r4 -> 192.168.50.20:  0% packet loss
+r4 -> 192.168.20.2:  0% packet loss
+r4 -> 192.168.20.3:  0% packet loss
+r4 -> 192.168.30.2:  0% packet loss
+r4 -> 192.168.30.3:  0% packet loss
+r4 -> 192.168.10.4:  0% packet loss
+r4 -> 192.168.40.2:  0% packet loss
+r4 -> 192.168.10.100:  0% packet loss
+r4 -> 192.168.20.100:  0% packet loss
+r4 -> 192.168.30.100:  0% packet loss
+r4 -> 192.168.40.100:  0% packet loss
+Connection to 127.0.0.1 closed.
 s1
 ========================
 ip route list:
@@ -170,17 +541,20 @@ default via 10.0.2.2 dev eth0
 10.0.2.0/24 dev eth0  proto kernel  scope link  src 10.0.2.15
 192.168.0.0/16 via 192.168.10.2 dev eth1
 192.168.10.0/24 dev eth1  proto kernel  scope link  src 192.168.10.100
-Connection to 127.0.0.1 closed.
-s1 -> 192.168.10.100:  0% packet loss
-s1 -> 192.168.20.100:  0% packet loss
-s1 -> 192.168.30.100:  0% packet loss
+s1 -> 192.168.50.10:  0% packet loss
 s1 -> 192.168.10.2:  0% packet loss
+s1 -> 192.168.50.20:  0% packet loss
 s1 -> 192.168.20.2:  0% packet loss
 s1 -> 192.168.20.3:  0% packet loss
 s1 -> 192.168.30.2:  0% packet loss
-s1 -> 192.168.50.10:  0% packet loss
-s1 -> 192.168.50.20:  0% packet loss
-
+s1 -> 192.168.30.3:  0% packet loss
+s1 -> 192.168.10.4:  0% packet loss
+s1 -> 192.168.40.2:  100% packet loss
+s1 -> 192.168.10.100:  0% packet loss
+s1 -> 192.168.20.100:  0% packet loss
+s1 -> 192.168.30.100:  0% packet loss
+s1 -> 192.168.40.100:  100% packet loss
+Connection to 127.0.0.1 closed.
 s2
 ========================
 ip route list:
@@ -188,17 +562,20 @@ default via 10.0.2.2 dev eth0
 10.0.2.0/24 dev eth0  proto kernel  scope link  src 10.0.2.15
 192.168.0.0/16 via 192.168.20.2 dev eth1
 192.168.20.0/24 dev eth1  proto kernel  scope link  src 192.168.20.100
-Connection to 127.0.0.1 closed.
-s2 -> 192.168.10.100:  0% packet loss
-s2 -> 192.168.20.100:  0% packet loss
-s2 -> 192.168.30.100:  0% packet loss
+s2 -> 192.168.50.10:  0% packet loss
 s2 -> 192.168.10.2:  0% packet loss
+s2 -> 192.168.50.20:  0% packet loss
 s2 -> 192.168.20.2:  0% packet loss
 s2 -> 192.168.20.3:  0% packet loss
 s2 -> 192.168.30.2:  0% packet loss
-s2 -> 192.168.50.10:  0% packet loss
-s2 -> 192.168.50.20:  0% packet loss
-
+s2 -> 192.168.30.3:  100% packet loss
+s2 -> 192.168.10.4:  100% packet loss
+s2 -> 192.168.40.2:  100% packet loss
+s2 -> 192.168.10.100:  0% packet loss
+s2 -> 192.168.20.100:  0% packet loss
+s2 -> 192.168.30.100:  0% packet loss
+s2 -> 192.168.40.100:  100% packet loss
+Connection to 127.0.0.1 closed.
 s3
 ========================
 ip route list:
@@ -206,14 +583,39 @@ default via 10.0.2.2 dev eth0
 10.0.2.0/24 dev eth0  proto kernel  scope link  src 10.0.2.15
 192.168.0.0/16 via 192.168.30.2 dev eth1
 192.168.30.0/24 dev eth1  proto kernel  scope link  src 192.168.30.100
-Connection to 127.0.0.1 closed.
-s3 -> 192.168.10.100:  0% packet loss
-s3 -> 192.168.20.100:  0% packet loss
-s3 -> 192.168.30.100:  0% packet loss
+s3 -> 192.168.50.10:  0% packet loss
 s3 -> 192.168.10.2:  0% packet loss
+s3 -> 192.168.50.20:  0% packet loss
 s3 -> 192.168.20.2:  0% packet loss
 s3 -> 192.168.20.3:  0% packet loss
 s3 -> 192.168.30.2:  0% packet loss
-s3 -> 192.168.50.10:  0% packet loss
-s3 -> 192.168.50.20:  0% packet loss
+s3 -> 192.168.30.3:  0% packet loss
+s3 -> 192.168.10.4:  0% packet loss
+s3 -> 192.168.40.2:  100% packet loss
+s3 -> 192.168.10.100:  0% packet loss
+s3 -> 192.168.20.100:  0% packet loss
+s3 -> 192.168.30.100:  0% packet loss
+s3 -> 192.168.40.100:  100% packet loss
+Connection to 127.0.0.1 closed.
+s4
+========================
+ip route list:
+default via 10.0.2.2 dev eth0
+10.0.2.0/24 dev eth0  proto kernel  scope link  src 10.0.2.15
+192.168.0.0/16 via 192.168.40.2 dev eth1
+192.168.40.0/24 dev eth1  proto kernel  scope link  src 192.168.40.100
+s4 -> 192.168.50.10:  100% packet loss
+s4 -> 192.168.10.2:  100% packet loss
+s4 -> 192.168.50.20:  100% packet loss
+s4 -> 192.168.20.2:  100% packet loss
+s4 -> 192.168.20.3:  100% packet loss
+s4 -> 192.168.30.2:  100% packet loss
+s4 -> 192.168.30.3:  0% packet loss
+s4 -> 192.168.10.4:  0% packet loss
+s4 -> 192.168.40.2:  0% packet loss
+s4 -> 192.168.10.100:  100% packet loss
+s4 -> 192.168.20.100:  100% packet loss
+s4 -> 192.168.30.100:  100% packet loss
+s4 -> 192.168.40.100:  0% packet loss
+Connection to 127.0.0.1 closed.
 ```

--- a/bgp-2/README.md
+++ b/bgp-2/README.md
@@ -43,6 +43,7 @@ Largely based on tutorial at http://xmodulo.com/centos-bgp-router-quagga.html
                                                                                     | s3 (server)            |
                                                                                     |                        |
                                                                                     +------------------------+
+```
 
 
 ## AS100

--- a/bgp-2/Vagrantfile
+++ b/bgp-2/Vagrantfile
@@ -1,6 +1,12 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+Interface = Struct.new(:ip, :netmask, :gateway) do
+  def initialize(ip, netmask = '255.255.255.0', gateway = nil)
+    super
+  end
+end
+
 ROUTER_CMDS=<<SHELL
   set -x
 
@@ -20,58 +26,75 @@ ROUTER_CMDS=<<SHELL
   umask=022 echo "export VTYSH_PAGER=more" > /etc/profile.d/vtysh_pager.sh
 SHELL
 
-routers = [
+
+ROUTERS = [
   { name: 'r1',
-    wan: { ip: '192.168.50.10', netmask: '255.255.255.0' },
-    lan: { ip: '192.168.10.2',  netmask: '255.255.255.0' } },
+    nics: [ Interface.new('192.168.50.10'),
+            Interface.new('192.168.10.2') ]},
   { name: 'r2',
-    wan: { ip: '192.168.50.20', netmask: '255.255.255.0' },
-    lan: { ip: '192.168.20.2',  netmask: '255.255.255.0' } },
+    nics: [ Interface.new('192.168.50.20'),
+            Interface.new('192.168.20.2') ]},
   { name: 'r3',
-    wan: { ip: '192.168.20.3',  netmask: '255.255.255.0' },
-    lan: { ip: '192.168.30.2',  netmask: '255.255.255.0' } },
+    nics: [ Interface.new('192.168.20.3'),
+            Interface.new('192.168.30.2') ]},
+  { name: 'r4',
+    nics: [ Interface.new('192.168.30.3'),
+            Interface.new('192.168.10.4'),
+            Interface.new('192.168.40.2') ]}
 ]
 
-servers = [
+SERVERS = [
   { name: 's1',
-    ip: '192.168.10.100', netmask: '255.255.255.0', gateway: '192.168.10.2' },
+    nics: [ Interface.new('192.168.10.100', '255.255.255.0', '192.168.10.2') ] },
   { name: 's2',
-    ip: '192.168.20.100', netmask: '255.255.255.0', gateway: '192.168.20.2' },
+    nics: [ Interface.new('192.168.20.100', '255.255.255.0', '192.168.20.2') ] },
   { name: 's3',
-    ip: '192.168.30.100', netmask: '255.255.255.0', gateway: '192.168.30.2' }
+    nics: [ Interface.new('192.168.30.100', '255.255.255.0', '192.168.30.2') ] },
+  { name: 's4',
+    nics: [ Interface.new('192.168.40.100', '255.255.255.0', '192.168.40.2') ] },
 ]
+
+all_ips = ROUTERS.map { |r| r[:nics] }.flatten.map(&:ip)
+all_ips += SERVERS.map { |r| r[:nics] }.flatten.map(&:ip)
+
+CMDS=<<SHELL
+set -x
+if [ ! -f '/tmp/apt.done' ]; then
+  apt-get update
+  apt-get install -qy tcpdump
+  touch /tmp/apt.done
+fi
+
+echo 'export IPADDRS="#{all_ips.join(' ')}"' > /usr/local/etc/ips
+SHELL
 
 Vagrant.configure("2") do |config|
   config.vm.box = "debian/jessie64"
-  config.vm.provision "shell", inline: "apt-get update && apt-get install -qy tcpdump"
+  config.vm.provision "shell", inline: CMDS
 
-  routers.each do |router|
+  ROUTERS.each do |router|
     config.vm.define router[:name] do |c|
       c.vm.hostname = router[:name]
-      # WAN eth1
-      c.vm.network "private_network", ip: router[:wan][:ip],
-                                      netmask: router[:wan][:netmask]
-      # LAN eth2
-      c.vm.network "private_network", ip: router[:lan][:ip],
-                                      netmask: router[:lan][:netmask]
+      router[:nics].each do |nic|
+        c.vm.network "private_network", nic.to_h
+      end
 
       c.vm.provision "shell", inline: ROUTER_CMDS
     end
   end
 
-  servers.each do |server|
+  SERVERS.each do |server|
     # servers
     config.vm.define server[:name] do |c|
       c.vm.hostname = server[:name]
-      # LAN
-      c.vm.network "private_network", ip: server[:ip],
-                                      netmask: server[:netmask],
-                                      gateway: server[:gateway]
+      server[:nics].each do |nic|
+        c.vm.network "private_network", nic.to_h
+      end
 
       # static route for all interal networks because Virtualbox configures its
       # own eth0 with the default gateway
       c.vm.provision "shell",
-        inline: "ip route add 192.168.0.0/16 via #{server[:gateway]} dev eth1 || true"
+        inline: "ip route add 192.168.0.0/16 via #{server[:nics].first.gateway} dev eth1 || true"
     end
   end
 end

--- a/bgp-2/debug.sh
+++ b/bgp-2/debug.sh
@@ -14,8 +14,7 @@ if [[ "$host" =~ ^r ]]; then
 fi
 
 for ipaddr in $IPADDRS; do
-#  result="$(ping -c1 "$ipaddr" | awk -F, '/packet loss/ {print $3}')"
-#  echo "$host -> $ipaddr: $result"
-  traceroute "$ipaddr"
+  result="$(ping -c1 "$ipaddr" | awk -F, '/packet loss/ {print $3}')"
+  echo "$host -> $ipaddr: $result"
 done
 

--- a/bgp-2/debug.sh
+++ b/bgp-2/debug.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+source "/usr/local/etc/ips"
+
+host="$(hostname -s)"
+
+echo "ip route list:"
+ip route list
+
+if [[ "$host" =~ ^r ]]; then
+  echo "BGP"
+  vtysh -c 'show ip bgp'
+  vtysh -c 'show ip bgp summary'
+fi
+
+for ipaddr in $IPADDRS; do
+#  result="$(ping -c1 "$ipaddr" | awk -F, '/packet loss/ {print $3}')"
+#  echo "$host -> $ipaddr: $result"
+  traceroute "$ipaddr"
+done
+

--- a/bgp-2/r1/bgpd.conf
+++ b/bgp-2/r1/bgpd.conf
@@ -10,8 +10,11 @@ log stdout
 router bgp 100
  bgp router-id 192.168.50.10
  network 192.168.10.0/24
+ network 192.168.50.0/24
  neighbor 192.168.50.20 remote-as 200
  neighbor 192.168.50.20 description "r2"
+ neighbor 192.168.10.4 remote-as 400
+ neighbor 192.168.10.4 description "r4"
 !
 line vty
 !

--- a/bgp-2/r3/bgpd.conf
+++ b/bgp-2/r3/bgpd.conf
@@ -8,9 +8,12 @@ log stdout
 !
 router bgp 300
  bgp router-id 192.168.20.3
+ network 192.168.20.0/24
  network 192.168.30.0/24
  neighbor 192.168.20.2 remote-as 200
  neighbor 192.168.20.2 description "r2"
+ neighbor 192.168.30.3 remote-as 400
+ neighbor 192.168.30.3 description "r4"
 !
 line vty
 !

--- a/bgp-2/r4/bgpd.conf
+++ b/bgp-2/r4/bgpd.conf
@@ -1,0 +1,20 @@
+!
+! Zebra configuration saved from vty
+!   2017/01/06 12:34:41
+!
+hostname bgpd
+password zebra
+log stdout
+!
+router bgp 400
+ bgp router-id 192.168.30.3
+ network 192.168.10.0/24
+ network 192.168.30.0/24
+ network 192.168.40.0/24
+ neighbor 192.168.30.2 remote-as 300
+ neighbor 192.168.30.2 description "r3"
+ neighbor 192.168.10.2 remote-as 100
+ neighbor 192.168.10.2 description "r1"
+!
+line vty
+!

--- a/bgp-2/r4/zebra.conf
+++ b/bgp-2/r4/zebra.conf
@@ -1,0 +1,33 @@
+!
+! Zebra configuration saved from vty
+!   2017/01/06 12:34:41
+!
+hostname Router
+password zebra
+enable password zebra
+!
+interface eth0
+ ipv6 nd suppress-ra
+!
+interface eth1
+ description "to r3"
+ ip address 192.168.30.3/24
+ ipv6 nd suppress-ra
+!
+interface eth2
+ description "r1 network"
+ ip address 192.168.10.4/24
+ ipv6 nd suppress-ra
+!
+interface eth3
+ description "r4 network"
+ ip address 192.168.40.2/24
+ ipv6 nd suppress-ra
+!
+interface lo
+!
+ip forwarding
+!
+!
+line vty
+!

--- a/bgp-2/test.sh
+++ b/bgp-2/test.sh
@@ -1,20 +1,9 @@
 #!/usr/bin/env bash
 
-IPADDRS="192.168.10.100 192.168.20.100 192.168.30.100 192.168.10.2 192.168.20.2 192.168.20.3 192.168.30.2 192.168.50.10 192.168.50.20"
 HOSTS=$(vagrant status | grep running | awk '{print $1}')
 
 for host in $HOSTS; do
   echo "$host"
   echo "========================"
-  echo "ip route list:"
-  vagrant ssh "$host" -c "ip route list"
-  if [[ "$host" =~ ^r ]]; then
-    echo "show ip bgp:"
-    vagrant ssh "$host" -c "sudo vtysh -c 'show ip bgp' && sudo vtysh -c 'show ip bgp summary'"
-  fi
-  for ipaddr in $IPADDRS; do
-    result=$(vagrant ssh "$host" -- ping -c1 "$ipaddr" | awk -F, '/packet loss/ {print $3}')
-    echo "$host -> $ipaddr: $result"
-  done
-  echo
+  vagrant ssh $host -c "sudo /vagrant/debug.sh"
 done


### PR DESCRIPTION
This adds AS400, which is reachable from AS100 and AS300. Shutting down `r2` or `r4` yields all devices still reachable except for the networks and interfaces directly managed by the router.